### PR TITLE
Fix not being able to disable output of scripts/include

### DIFF
--- a/src/builder/builder.ts
+++ b/src/builder/builder.ts
@@ -180,6 +180,10 @@ export default class AmxxBuilder {
   }
 
   async updateInclude(filePath: string): Promise<void> {
+    if (!this.projectConfig.output.include) {
+      return;
+    }
+
     const destPath = path.join(this.projectConfig.output.include, path.parse(filePath).base);
 
     await mkdirp(this.projectConfig.output.include);

--- a/src/project-config/defaults.ts
+++ b/src/project-config/defaults.ts
@@ -7,9 +7,9 @@ export default {
     assets: './assets',
   },
   output: {
-    scripts: './dist/addons/amxmodx/scripting',
+    scripts: '',
     plugins: './dist/addons/amxmodx/plugins',
-    include: './dist/addons/amxmodx/scripting/include',
+    include: '',
     assets: './dist'
   },
   compiler: {

--- a/src/project-config/defaults.ts
+++ b/src/project-config/defaults.ts
@@ -7,9 +7,9 @@ export default {
     assets: './assets',
   },
   output: {
-    scripts: '',
+    scripts: './dist/addons/amxmodx/scripting',
     plugins: './dist/addons/amxmodx/plugins',
-    include: '',
+    include: './dist/addons/amxmodx/scripting/include',
     assets: './dist'
   },
   compiler: {

--- a/src/project-config/resolve.ts
+++ b/src/project-config/resolve.ts
@@ -9,7 +9,7 @@ function resolve(
   overrides: PartialDeep<IProjectConfig> = {},
   projectDir: string = ''
 ): IResolvedProjectConfig {
-  const resolvePath = (p: string) => path.resolve(projectDir || '', p);
+  const resolvePath = (p: string) => p.length == 0 ? '' : path.resolve(projectDir || '', p);
 
   const config: IProjectConfig = merge({}, defaults, overrides);
 


### PR DESCRIPTION
This fixes #10

The issue is found in `resolvePath()` which will always use the projectDir string which in my case is `C:\Users\rtxa\Documents\GitHub\agmodx`. In any case, I added a check that avoid using it if the argument length is 0.

Added missing guard clause on `updateInclude()` to avoid updating on empty path which matchs the one from `updateScript`.

I removed the default arguments on `default.ts` to allow being disabled by not specifying it. The default arguments are already provided by the default  `.amxxpack.json` on configuration. Otherwise, you should specify an empty string to disable the option. If you don't feel this right, let me know, anyway is not a big issue specifying an empty string.

**Not specified**
```json
  "output": {
    "plugins": "C:/Users/rtxa/Documents/Servidores HL/AG Mod X/valve/addons/amxmodx/plugins",
    "assets": "C:/Users/rtxa/Documents/Servidores HL/AG Mod X/valve"
  },
```

**Using empty string**

```json
  "output": {
    "plugins": "C:/Users/rtxa/Documents/Servidores HL/AG Mod X/valve/addons/amxmodx/plugins",
    "assets": "C:/Users/rtxa/Documents/Servidores HL/AG Mod X/valve",
    "scripts": "",
    "include": ""
  },
```